### PR TITLE
Add `html` and `latexpdf` targets explicitly for VSCode to find

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -16,5 +16,5 @@ help:
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
+html latexpdf %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -9,12 +9,12 @@ SOURCEDIR     = .
 BUILDDIR      = build
 
 # Put it first so that "make" without argument is like "make help".
-help:
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+help html latexpdf:
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: help html latexpdf Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-html latexpdf %: Makefile
+%: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)


### PR DESCRIPTION
* VSCode's Makefile Tools runs a command to generate the list of
  available targets for configurations as the default build target:

  ```console
  make all --print-data-base --no-builtin-variables --no-builtin-rules --question
  ```

  When configuring the "Build target," one is only able to select from
  the generated list, so we add `html` and `latexpdf` explicitly to
  allow VSCode to find them programmatically via the above command.
