### PR TITLE
Update conda instructions and environment file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ To build the document:
     - If you do not already have all the necessary software installed, you might install [Conda](https://conda-forge.org/download/), and use Conda to install the required products. Full documentation for Conda is available at <https://docs.conda.io/en/latest/>.  Assuming you already have a LaTeX installation, the following Conda command will install everything else you need into an environment named `for-dune-framework-docs`.
 
       ```console
-      conda create -n for-dune-framework-docs sphinx plantuml doxygen pandoc sphinx-needs
+      conda env create --name for-dune-framework-docs --file environment.yml
       ```
 
-1. Navigate to the `doc` subdirectory and type `make latexpdf`.
+1. Navigate to the `doc` subdirectory and type `make latexpdf`, or run `make -C doc latexpdf` from the root directory of this repository.
 
 ## Developing the design document in VSCode
 
@@ -33,7 +33,7 @@ If you wish to develop documentation in VSCode, we make the following suggestion
 1. Ensure the availability of the following Python packages (e.g. via conda):
 
    ```console
-   conda install -n for-dune-framework-docs doc8 esbonio rstcheck
+   conda install --name for-dune-framework-docs doc8 esbonio rstcheck
    ```
 
 1. Make the following additions to `.vscode/settings.json`, adjusting paths as necessary:

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,10 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - sphinx[version='>=8.2']
-  - sphinx-needs
-  - graphviz2drawio
-  - graphviz[version='>=12']
+  - plantuml
+  - sphinx=9.1.0
+  - doxygen
+  - sphinxcontrib-jquery
+  - sphinx-needs=8.1.1
+  - pandoc
+  - python=3.13.2

--- a/environment.yml
+++ b/environment.yml
@@ -3,9 +3,9 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - plantuml
+  - graphviz2drawio
+  - graphviz[version='>=12']
   - sphinx=9.1.0
-  - doxygen
   - sphinxcontrib-jquery
   - sphinx-needs=8.1.1
   - pandoc


### PR DESCRIPTION
The `environment.yml` file was out-of-date, and the instructions for creating a conda environment neither followed best practices nor even used the environment file.

This PR updates both the instructions to follow best practice and the environment.yml file to install all tools needed (except for latex). It has been verified only on macOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Documentation & Setup Instructions
- Updated README.md conda environment setup to follow best practices by replacing `conda create ...` with `conda env create --file environment.yml` workflow
- Adjusted VSCode/documentation dependency installation command to include `--name for-dune-framework-docs` flag for consistency

## Build Configuration
- Updated `environment.yml` with pinned versions of key documentation tools:
  - `sphinx=9.1.0`
  - `sphinx-needs=8.1.1`
  - `python=3.13.2`
- Added new documentation/build tools:
  - `plantuml`
  - `doxygen`
  - `sphinxcontrib-jquery`
  - `pandoc`
- Removed generic Sphinx and graphviz dependencies that were replaced with pinned versions

## Verification
- Changes validated on macOS

<!-- end of auto-generated comment: release notes by coderabbit.ai -->