### PR TITLE
Create wiki folder

### DIFF
--- a/design_wiki/design-ideas-wiki.md
+++ b/design_wiki/design-ideas-wiki.md
@@ -1,0 +1,15 @@
+## Phlex Design Ideas Wiki
+
+This directory and the subdirectories under it contain what is intended to be a fairly fluid set of design notes that are not yet mature enough to be put into the design document itself.
+
+There are two immediate subdirectories, `seeds` and `saplings`.
+`seeds` is the directory to use for new ideas that are just being formed, and are still quite immature.
+It will be common to find that there are inconsistencies to be reconciled in the various notes in `seeds`.
+The directory `saplings` contains notes that are more mature than those in `seeds`, but not yet mature enough to be migrated out of this directory and into the design document itself.
+
+The typical lifetime of notes will be to start in the `seeds` directory, to be edited, merged, split as needed.
+When reaching a certain degree of maturity (perhaps indicated by group consensus in meetings), the notes can be migrated to the `saplings` directory.
+After sufficient maturity is reached, and when there is clear group agreement, notes can be moved out of `saplings` and into the design document proper.
+
+Sometimes these notes may repeat facts that are already recorded in the design document.
+This is acceptable when needed for clarity, but such duplication should be removed as the notes mature, and should generally be removed when items are migrated to the design document.

--- a/design_wiki/design-ideas-wiki.md
+++ b/design_wiki/design-ideas-wiki.md
@@ -7,8 +7,10 @@ There are two immediate subdirectories, `seeds` and `saplings`.
 It will be common to find that there are inconsistencies to be reconciled in the various notes in `seeds`.
 The directory `saplings` contains notes that are more mature than those in `seeds`, but not yet mature enough to be migrated out of this directory and into the design document itself.
 
-The typical lifetime of notes will be to start in the `seeds` directory, to be edited, merged, split as needed.
-When reaching a certain degree of maturity (perhaps indicated by group consensus in meetings), the notes can be migrated to the `saplings` directory.
+The typical life cycle of notes will be to start in the `seeds` directory, to be edited, merged, split as needed.
+Notes in `seeds` will typically be ideas from an individual or very small group.
+They are not yet ready for the wider group to review, and may be inconsistent with other notes in `seeds` or with the design document itself.
+When reaching a certain degree of maturity (when they are ready to be considered by the whole group), a set of notes should be migrated to the `saplings` directory.
 After sufficient maturity is reached, and when there is clear group agreement, notes can be moved out of `saplings` and into the design document proper.
 
 Sometimes these notes may repeat facts that are already recorded in the design document.

--- a/design_wiki/saplings/Index.md
+++ b/design_wiki/saplings/Index.md
@@ -1,0 +1,1 @@
+This is the `saplings` directory, for design notes more mature than `seeds` but not yet ready to be moved to the design document.

--- a/design_wiki/seeds/Index.md
+++ b/design_wiki/seeds/Index.md
@@ -1,1 +1,0 @@
-This is the `seed` directory, for newly-formed notes and ideas.

--- a/design_wiki/seeds/Index.md
+++ b/design_wiki/seeds/Index.md
@@ -1,0 +1,1 @@
+This is the `seed` directory, for newly-formed notes and ideas.

--- a/design_wiki/seeds/form-io-interface.md
+++ b/design_wiki/seeds/form-io-interface.md
@@ -1,0 +1,5 @@
+## FORM IO Interface
+
+1. When Phlex presents a data produce to be written, that data product must have [full identifying metadata](how-data-products-are-labeled.md) associated with it.
+   FORM must then be able to use those metadata to identify the unique data product associated with the metadata.
+   

--- a/design_wiki/seeds/form-io-interface.md
+++ b/design_wiki/seeds/form-io-interface.md
@@ -1,5 +1,5 @@
 ## FORM IO Interface
 
-1. When Phlex presents a data produce to be written, that data product must have [full identifying metadata](how-data-products-are-labeled.md) associated with it.
+1. When Phlex presents a data product to be written, that data product must have [full identifying metadata](how-data-products-are-labeled.md) associated with it.
    FORM must then be able to use those metadata to identify the unique data product associated with the metadata.
    

--- a/design_wiki/seeds/how-data-products-are-labeled.md
+++ b/design_wiki/seeds/how-data-products-are-labeled.md
@@ -1,0 +1,19 @@
+## How Data Products Are Labeled
+
+1. The main data type for the labeling of data products is `product_specification`
+2. The type `product_specification` may not actually hold *all* of the data needed to label a data product.
+3. FORM storage of data products must ensure that the full metadata must be associated with each product.
+4. The [FORM IO interface](form-io-interface.md) must allow finding and reading a product by providing a `product_selector` that matches some fraction of these metadata.
+    Form must be able to either read the associated data product or to report that the specification is ambiguous.
+    If the specification is ambiguous the matching candidates should be identified and the returned error message should include the metadata of those candidates.
+
+### The Data Required for Complete Product Specification
+
+Complete product specification means that this information is sufficient to uniquely identify a single data product.
+
+1. creator (also called node name) (plugin_name + algorithm_name)
+2. suffix
+3. type_id (the concrete type id)
+4. stage_name
+5. a set of data cell indices identify which data-cells the product is associated with
+6. a data-product concept

--- a/design_wiki/seeds/registries.md
+++ b/design_wiki/seeds/registries.md
@@ -1,0 +1,24 @@
+## Registries
+
+### The Need for a Registry of Data-Product Concepts
+
+An important reason (perhaps the main reason) for having a registry of data product concepts it related to the need to generate [implicit providers](the-nature-of-implicit-providers.md).
+Closely related is the need to generate [translator nodes](the-nature-of-translator-nodes.md) to connect calculation nodes.
+
+During graph building, when a calculation node in the graph has an input for which no matching output from another node is found, the graph building system must:
+1. Discover the [data-product concept](the-nature-of-data-product-concepts.md) associated with the unmatched input.
+2. Determine if the output from another node is a match *except for* the concrete data-product type (if it were also a match for the concrete data-product type, then this would not be an unrequited input!); the graph builder needs to collect the full set of such candidate matches
+3. Determine whether there is a [translator function](the-nature-of-translator-functions.md) that can create the unrequited input:
+	1. from the output of one of the elements in the set of candidate matches (from above) *or*
+	2. by reading from the input file, perhaps followed by the application of a translator function.
+
+Thus the graph-building process must be able to find translators related to a data-product concept.
+A registry of data-product concepts can be used to meet this need.
+
+### How Data-Product Concepts Are Added to the Registry
+
+1. Every computational node that creates a data product should have a data-product concept associate with the concrete data product type.
+2. At the time of the creation of the computational node, the system should add the concept to the registry.
+   Note that it is possible that the given concept is already in the registry.
+3. At the same time the concrete data product type should be associated with the concept in the registry.
+   Note that it is possible that this concrete data product type is already associated with the concept.

--- a/design_wiki/seeds/registries.md
+++ b/design_wiki/seeds/registries.md
@@ -1,9 +1,16 @@
 ## Registries
 
+### The Nature of a Registry
+
+In this context the registry being discussed is an object in the running program.
+A data-product concept registry would be owned by the `framework_graph`.
+There would be only one registry for data-product concepts in any program.
+It would not be a global variable (or singleton) but would be owned by the `framework_graph` and passed to whatever functions need it.
+
 ### The Need for a Registry of Data-Product Concepts
 
-An important reason (perhaps the main reason) for having a registry of data product concepts it related to the need to generate [implicit providers](the-nature-of-implicit-providers.md).
-Closely related is the need to generate [translator nodes](the-nature-of-translator-nodes.md) to connect calculation nodes.
+An important reason (perhaps the main reason) for having a registry of data product concepts is related to the need to generate [implicit providers](the-nature-of-implicit-providers.md).
+Closely related is the need to generate [translator nodes](the-nature-of-translator-nodes.md) to connect computational nodes.
 
 During graph building, when a calculation node in the graph has an input for which no matching output from another node is found, the graph building system must:
 1. Discover the [data-product concept](the-nature-of-data-product-concepts.md) associated with the unmatched input.
@@ -17,8 +24,10 @@ A registry of data-product concepts can be used to meet this need.
 
 ### How Data-Product Concepts Are Added to the Registry
 
-1. Every computational node that creates a data product should have a data-product concept associate with the concrete data product type.
+1. Every computational node that creates a data product should have a data-product concept associated with the concrete data product type.
 2. At the time of the creation of the computational node, the system should add the concept to the registry.
-   Note that it is possible that the given concept is already in the registry.
-3. At the same time the concrete data product type should be associated with the concept in the registry.
-   Note that it is possible that this concrete data product type is already associated with the concept.
+3. The data product concept should be associated with the concrete data product type being added to registry.
+4. Note that it is possible that the given concept is already in the registry; then all that is needed is to add the new concrete data product type to the set of concrete data product types associated with the concept in the registry.
+5. At the same time the concrete data product type should be associated with the concept in the registry.
+6. Note that it is possible that this concrete data product type is already associated with the concept.
+

--- a/design_wiki/seeds/scenarios.md
+++ b/design_wiki/seeds/scenarios.md
@@ -1,0 +1,3 @@
+## Processing Scenarios
+
+### Exact Match to Input

--- a/design_wiki/seeds/the-nature-of-concrete-data-product-types.md
+++ b/design_wiki/seeds/the-nature-of-concrete-data-product-types.md
@@ -1,0 +1,1 @@
+## The Nature of Concrete Data Product Types

--- a/design_wiki/seeds/the-nature-of-data-product-concepts.md
+++ b/design_wiki/seeds/the-nature-of-data-product-concepts.md
@@ -1,4 +1,4 @@
 ## The Nature of Data Product Concepts
 
 1. A data-product concept is an abstraction that capture the computationally-relevant aspects of a physical data product.
-2. A data-product concept is associated with one or more [concrete data-product types](the-nature-of-concrete-data-product-types).
+2. A data-product concept is associated with one or more [concrete data-product types](the-nature-of-concrete-data-product-types.md).

--- a/design_wiki/seeds/the-nature-of-data-product-concepts.md
+++ b/design_wiki/seeds/the-nature-of-data-product-concepts.md
@@ -2,3 +2,4 @@
 
 1. A data-product concept is an abstraction that capture the computationally-relevant aspects of a physical data product.
 2. A data-product concept is associated with one or more [concrete data-product types](the-nature-of-concrete-data-product-types.md).
+3. It must be possible to add new concrete data-product types to an existing concept object.

--- a/design_wiki/seeds/the-nature-of-data-product-concepts.md
+++ b/design_wiki/seeds/the-nature-of-data-product-concepts.md
@@ -1,0 +1,4 @@
+## The Nature of Data Product Concepts
+
+1. A data-product concept is an abstraction that capture the computationally-relevant aspects of a physical data product.
+2. A data-product concept is associated with one or more [concrete data-product types](the-nature-of-concrete-data-product-types).

--- a/design_wiki/seeds/the-nature-of-implicit-providers.md
+++ b/design_wiki/seeds/the-nature-of-implicit-providers.md
@@ -1,0 +1,3 @@
+## The Nature of Implicit Providers
+
+1. An *implicit provider* is one that is created by the graph building procedure to meet the input needs of a Phlex program.

--- a/design_wiki/seeds/the-nature-of-translator-functions.md
+++ b/design_wiki/seeds/the-nature-of-translator-functions.md
@@ -1,0 +1,8 @@
+## The Nature of Translator Functions
+
+The name *translator function* should be preferred to *translator*, to avoid confusion with the term [Translator Node](The Nature of Translator Nodes.md).
+1. A translator function converts an object of one concrete data-product type into an object of a different concrete data-product type that models the same data-product concept.
+2. Translators are added to the graph as necessary.
+3. A single data-product concept may have multiple concrete representations, such as different language bindings or GPU- and CPU-friendly layouts.
+4. A single concrete type may also represent multiple data-product concepts.
+5. The framework should be able to discover translator functions and select which ones are needed in [translator nodes](the-nature-of-translator-nodes.md) belong in the graph without loading every discovered translator DLL.

--- a/design_wiki/seeds/the-nature-of-translator-functions.md
+++ b/design_wiki/seeds/the-nature-of-translator-functions.md
@@ -1,6 +1,6 @@
 ## The Nature of Translator Functions
 
-The name *translator function* should be preferred to *translator*, to avoid confusion with the term [Translator Node](The Nature of Translator Nodes.md).
+The name *translator function* should be preferred to *translator*, to avoid confusion with the term [Translator Node](the-nature-of-translator-nodes.md).
 1. A translator function converts an object of one concrete data-product type into an object of a different concrete data-product type that models the same data-product concept.
 2. Translators are added to the graph as necessary.
 3. A single data-product concept may have multiple concrete representations, such as different language bindings or GPU- and CPU-friendly layouts.

--- a/design_wiki/seeds/the-nature-of-translator-nodes.md
+++ b/design_wiki/seeds/the-nature-of-translator-nodes.md
@@ -1,0 +1,17 @@
+## The Nature of Translator Nodes
+
+A *translator  node* is a node whose input is of one concrete data-product type and whose output is of a different concrete data-product type, with both types modeling the same data-product concept.
+
+1. Each translator node uses a single [translator function](the-nature-of-translator-functions).
+2. A translator node is automatically inserted into the graph between two nodes whose data-product types are concept-compatible but not identical.
+3. Translator nodes belong to the computational graph.
+4. There are no translator nodes that precede a provider.
+5. There are no translator nodes that follow a preserver.
+6. There should never be two translator nodes that take the same input concrete data product and produce the same output concrete data product.
+7. Translator nodes are not configured directly by the framework user; they must be discovered by the framework based on needs implied by the user configuration.
+8. The translator metadata required for graph building should be generated at the time the translator plugin is compiled and linked.
+9. Translator nodes record in the metadata associated with their output product that they created the output data product.
+10. The *creator name* of the output data product must be identical to the *creator name* of the input data product.
+11. There must be some additional piece of metadata associated with the output data product that records the translation and what did it.
+12. Some translator nodes need to propagate a reference to the original data product for object-ownership purposes.
+13. This is needed when the implementation of the output concrete data product makes use of a reference to the input concrete data product, to avoid copying data.


### PR DESCRIPTION
This is the start of introducing a wiki-like set of files to be used to as "a fairly fluid set of design notes that are not yet mature enough to be put into the design document itself."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Docs / design wiki**
  - Added an initial `design_wiki` structure as a living space for design notes that are not yet ready for the main design document.
  - Introduced a top-level wiki overview plus `seeds` and `saplings` guidance pages describing the maturity flow from rough ideas to near-ready notes.
  - Added several seed documents covering core design concepts: FORM IO metadata requirements, data product labeling, registries, processing scenarios, concrete data product types, data product concepts, implicit providers, translator functions, and translator nodes.

- **Build system / environment**
  - Updated `environment.yml` to reflect the documentation toolchain more explicitly, including pinned Sphinx/Needs versions and related doc-generation dependencies.
  - Adjusted README Conda setup instructions to create the docs environment from `environment.yml` and aligned the VSCode environment command syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->