### PR TITLE
Tweak persistent-references prompt

### DIFF
--- a/phlex-art-comparison-prompt.md
+++ b/phlex-art-comparison-prompt.md
@@ -20,8 +20,8 @@ Steering notes:
 
 Context:
 
-- Phlex: `phlex/`
-- Phlex design and auxiliary documents `phlex-design/`.
-- `phlex-examples/`
-- Art: `art-suite/art-root-io/` and those dependencies also in `art-suite/`
-- LArSoft: `larsoft/larana` and those dependencies also in `larsoft/`
+- Phlex: `github.com/Framework-R-D/phlex/`
+- Phlex design and auxiliary documents `github.com/Framework-R-D/phlex-design/`.
+- `github.com/Framework-R-D/phlex-examples/`
+- Art: `github.com/art-framework-suite/art-root-io/` and those dependencies also in `github.com/art-framework-suite/`
+- LArSoft: `github.com/LArSoft/larana` and those dependencies also in `github.com/LArSoft/`


### PR DESCRIPTION
Not sure how important these adjustments are.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Documentation**
  - Updated persistent-reference links in `phlex-art-comparison-prompt.md` to canonical GitHub URLs for Phlex, its design and auxiliary documentation, Phlex examples, Art, and LArSoft.
  - Replaced relative path-style repository references with direct online locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->